### PR TITLE
Update poolWorker.js

### DIFF
--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -169,7 +169,10 @@ module.exports = function(logger){
 
         var pool = Stratum.createPool(poolOptions, authorizeFN, logger);
         pool.on('share', function(isValidShare, isValidBlock, data){
-
+		
+			if(data.worker != undefined)
+				data.worker = data.worker.replace(/:/g,"-")           
+            
             var shareData = JSON.stringify(data);
 
             if (data.blockHash && !isValidBlock)


### PR DESCRIPTION
1：修复挖矿地址中带有冒号的矿机编号会不出块.
2：修复扣块攻击的其中一种方法